### PR TITLE
MAT-828 dependency management hapi fhir deps

### DIFF
--- a/hapi-fhir-jpaserver/pom.xml
+++ b/hapi-fhir-jpaserver/pom.xml
@@ -13,9 +13,6 @@
     <name>hapi-fhir-jpaserver</name>
     <description>Hhapi-fhir-jpaserver Spriing Boot</description>
 
-    <properties>
-        <hapi.fhir.version>4.1.0</hapi.fhir.version>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/hapi-fhir-jpaserver/pom.xml
+++ b/hapi-fhir-jpaserver/pom.xml
@@ -139,12 +139,6 @@
             <version>2.15.1</version>
         </dependency>
 
-        <!-- Test -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/mat-fhir-services/pom.xml
+++ b/mat-fhir-services/pom.xml
@@ -66,13 +66,11 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-structures-r4</artifactId>
-            <version>4.0.1</version>
         </dependency>
 
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-client</artifactId>
-            <version>4.0.1</version>
         </dependency>
 
         <!-- For VSAC CLIENT -->
@@ -84,12 +82,10 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-validation-resources-r4</artifactId>
-            <version>4.0.1</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-validation</artifactId>
-            <version>4.0.1</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/components/library/FileHandler.java
+++ b/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/components/library/FileHandler.java
@@ -2,10 +2,10 @@ package gov.cms.mat.fhir.services.components.library;
 
 import gov.cms.mat.fhir.services.exceptions.ConfigException;
 import gov.cms.mat.fhir.services.exceptions.LibraryFileNotFoundException;
-import org.eclipse.jetty.io.RuntimeIOException;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -41,7 +41,7 @@ public interface FileHandler {
                     .sorted()
                     .collect(Collectors.toList());
         } catch (IOException e) {
-            throw new RuntimeIOException(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -53,7 +53,7 @@ public interface FileHandler {
             try {
                 return new String(Files.readAllBytes(cqlPath));
             } catch (IOException e) {
-                throw new RuntimeIOException(e);
+                throw new UncheckedIOException(e);
             }
         } else {
             throw new LibraryFileNotFoundException(name);

--- a/mat-rest-commons/pom.xml
+++ b/mat-rest-commons/pom.xml
@@ -22,7 +22,6 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-structures-r4</artifactId>
-            <version>4.0.1</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <mat.microservices.version>0.0.1-SNAPSHOT</mat.microservices.version>
+        <hapi.fhir.version>4.1.0</hapi.fhir.version>
     </properties>
 
     <dependencies>
@@ -44,6 +45,26 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>hapi-fhir-client</artifactId>
+                <version>${hapi.fhir.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>hapi-fhir-structures-r4</artifactId>
+                <version>${hapi.fhir.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>hapi-fhir-validation</artifactId>
+                <version>${hapi.fhir.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>hapi-fhir-validation-resources-r4</artifactId>
+                <version>${hapi.fhir.version}</version>
+            </dependency>
             <dependency>
                 <groupId>gov.cms.mat</groupId>
                 <artifactId>mat-fhir-commons</artifactId>


### PR DESCRIPTION
use HAPI FHIR dependency version 4.1.0 
use dependencyManagement in parent pom to manage version
fix build error - switch to use UncheckedIOException
remove duplicate dependency for spring-boot-starter-test