### PR TITLE
MAT-1176 Only overwrite fields on cqlToMatXml if source is fhir.

### DIFF
--- a/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/rest/MatXmlController.java
+++ b/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/rest/MatXmlController.java
@@ -205,12 +205,12 @@ public class MatXmlController {
         matXmlResponse.setCql(cql);
         matXmlResponse.setCqlModel(cqlToMatXml.getDestinationModel());
 
-        if (sourceModel != null) {
+        if (sourceModel != null && sourceModel.isFhir()) {
             // Overwrite fields the user is not allowed to change for FHIR.
-            matXmlResponse.getCqlModel().setLibraryName(sourceModel.getLibraryName());
-            matXmlResponse.getCqlModel().setUsingModelVersion(sourceModel.getUsingModelVersion());
             matXmlResponse.getCqlModel().setUsingModel(sourceModel.getUsingModel());
             matXmlResponse.getCqlModel().setVersionUsed(sourceModel.getVersionUsed());
+            matXmlResponse.getCqlModel().setLibraryName(sourceModel.getLibraryName());
+            matXmlResponse.getCqlModel().setUsingModelVersion(sourceModel.getUsingModelVersion());
         }
 
         if (!cqlToMatXml.getErrors().isEmpty()) {


### PR DESCRIPTION
Changed the controller to only overwrite fields if source model is FHIR. This prevents it from using QDMs version/model if that is passed in as source.