### PR TITLE
BUGFIX Fixed issue where cql was disappearing 

### DIFF
--- a/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/cql/parser/CqlToMatXml.java
+++ b/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/cql/parser/CqlToMatXml.java
@@ -67,6 +67,8 @@ public class CqlToMatXml implements CqlVisitor {
     public static final Pattern LIBRARY_VERSION_PATTERN = Pattern.compile(LIB_VERSION_REGEX);
     public static final String SNOWMED_URL = "http://snomed.info/sct";
 
+
+
     @Value("${mat.codesystem.valueset.simultaneous.validations}")
     private int simultaneousValidations;
     @Value("${mat.qdm.default.expansion.id}")

--- a/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/service/ValidationOrchestrationService.java
+++ b/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/service/ValidationOrchestrationService.java
@@ -17,6 +17,7 @@ import mat.model.cql.CQLParameter;
 import mat.server.CQLUtilityClass;
 import org.apache.commons.collections4.CollectionUtils;
 import org.hl7.cql.model.DataType;
+import org.hl7.elm.r1.Element;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -160,9 +161,12 @@ public class ValidationOrchestrationService {
         for (CQLDefinition definition : sourceModel.getDefinitionList()) {
             String definitionName = definition.getName();
             CQLExpressionObject expression = new CQLExpressionObject("Definition", definitionName);
-            DataType result = cqlToELM.getExpression(definitionName).getResultType();
-            if (result != null) {
-                expression.setReturnType(cqlToELM.getExpression(definitionName).getResultType().toString());
+            Element returnType = cqlToELM.getExpression(definitionName);
+            if (returnType != null) {
+                DataType result = returnType.getResultType();
+                if (result != null) {
+                    expression.setReturnType(cqlToELM.getExpression(definitionName).getResultType().toString());
+                }
             }
             cqlObject.getCqlDefinitionObjectList().add(expression);
         }


### PR DESCRIPTION
This was because of some bad code when finding the end of a define. Also fixed some side effects from that where return type couldn't be determined. The word code actually can appear in a define and shouldn't be used for defines/functions just paramaters.