### PR TITLE
[MAT-2686, MAT-2687] Remove One Time Service Endpoints

### DIFF
--- a/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/repository/FhirConversionHistoryRepository.java
+++ b/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/repository/FhirConversionHistoryRepository.java
@@ -1,9 +1,0 @@
-package gov.cms.mat.fhir.services.repository;
-
-import gov.cms.mat.fhir.commons.model.FhirConversionHistory;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface FhirConversionHistoryRepository extends JpaRepository<FhirConversionHistory, String> {
-}

--- a/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/repository/MeasureRepository.java
+++ b/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/repository/MeasureRepository.java
@@ -16,9 +16,4 @@ public interface MeasureRepository extends JpaRepository<Measure, String> {
 
     @Query("select ms.id from Measure ms where ms.draft = false and ms.releaseVersion in :allowedVersions")
     List<String> findAllIdsWithAllowedVersions(Collection<String> allowedVersions);
-
-    @Query("select m from Measure m where m.measureModel = \'FHIR\' and m.measureSetId in " +
-            "(select ms.measureSetId from Measure ms WHERE ms.measureSetId = m.measureSetId and " +
-            "ms.measureModel = \'QDM\')")
-    List<Measure> getAllConvertedFhirMeasures();
 }

--- a/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/repository/MeasureSetRepository.java
+++ b/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/repository/MeasureSetRepository.java
@@ -1,9 +1,0 @@
-package gov.cms.mat.fhir.services.repository;
-
-import gov.cms.mat.fhir.commons.model.MeasureSet;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface MeasureSetRepository extends JpaRepository<MeasureSet, String> {
-}

--- a/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/rest/MeasureController.java
+++ b/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/rest/MeasureController.java
@@ -1,34 +1,17 @@
 package gov.cms.mat.fhir.services.rest;
 
-import gov.cms.mat.fhir.commons.model.CqlLibrary;
-import gov.cms.mat.fhir.commons.model.FhirConversionHistory;
-import gov.cms.mat.fhir.commons.model.MeasureSet;
 import gov.cms.mat.fhir.services.exceptions.HapiResourceNotFoundException;
 import gov.cms.mat.fhir.services.hapi.HapiFhirServer;
-import gov.cms.mat.fhir.services.repository.CqlLibraryRepository;
-import gov.cms.mat.fhir.services.repository.FhirConversionHistoryRepository;
-import gov.cms.mat.fhir.services.repository.MeasureRepository;
-import gov.cms.mat.fhir.services.repository.MeasureSetRepository;
 import gov.cms.mat.fhir.services.translate.MeasureMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.r4.model.Measure;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 
 @RestController
 @RequestMapping(path = "/measure")
@@ -37,25 +20,10 @@ import java.util.UUID;
 public class MeasureController {
     private final HapiFhirServer hapiFhirServer;
     private final MeasureMapper measureMapper;
-    private final MeasureRepository measureRepository;
-    private final FhirConversionHistoryRepository fhirConversionHistoryRepository;
-    private final MeasureSetRepository measureSetRepository;
-    private final CqlLibraryRepository cqlLibraryRepository;
 
-    public MeasureController(HapiFhirServer hapiFhirServer,
-                             MeasureMapper measureMapper, MeasureRepository measureRepository, FhirConversionHistoryRepository fhirConversionHistoryRepository, MeasureSetRepository measureSetRepository, CqlLibraryRepository cqlLibraryRepository) {
+    public MeasureController(HapiFhirServer hapiFhirServer, MeasureMapper measureMapper) {
         this.hapiFhirServer = hapiFhirServer;
         this.measureMapper = measureMapper;
-        this.measureRepository = measureRepository;
-        this.fhirConversionHistoryRepository = fhirConversionHistoryRepository;
-        this.measureSetRepository = measureSetRepository;
-        this.cqlLibraryRepository = cqlLibraryRepository;
-    }
-
-    @Getter
-    @Setter
-    public static class ConvertFhirMeasureResult {
-        private Map<String, List<String>> successSetIdToFhirMeasures = new HashMap<>();
     }
 
     @Operation(summary = "Find a Hapi FHIR Library with the id",
@@ -82,67 +50,5 @@ public class MeasureController {
     @DeleteMapping(path = "/deleteAll")
     public int deleteMeasures() {
         return measureMapper.deleteAll();
-    }
-
-    /**
-     * Remove me after FHIR 6.04 release.
-     * @return
-     */
-    @Operation(summary = "For 6.04 release, converts libs to new set id. Not usable after 6.04 release")
-    @GetMapping("/dbConversionForFhirConversionIn6dot04")
-    public @ResponseBody ConvertFhirMeasureResult dbConversionForFhirConversionIn6dot04() {
-        ConvertFhirMeasureResult result = new ConvertFhirMeasureResult();
-        var fhirMeasureList = measureRepository.getAllConvertedFhirMeasures();
-
-        //Place in a map by qdm set id.
-        var mapBySetId = new HashMap<String, List<gov.cms.mat.fhir.commons.model.Measure>>();
-        fhirMeasureList.forEach(m -> {
-            List<gov.cms.mat.fhir.commons.model.Measure> measures = mapBySetId.get(m.getMeasureSetId().getId());
-            if (measures == null) {
-                measures = new ArrayList<>();
-                mapBySetId.put(m.getMeasureSetId().getId(), measures);
-            }
-            measures.add(m);
-        });
-
-        mapBySetId.forEach((k, v) -> {
-            if (fhirConversionHistoryRepository.findById(k).isEmpty()) {
-                String newSetId = UUID.randomUUID().toString();
-                //Create new FhirConversionHistory.
-                var h = new FhirConversionHistory();
-                h.setFhirSetId(newSetId);
-                h.setQdmSetId(k);
-                h.setLastModifiedOn(new Timestamp(System.currentTimeMillis()));
-                fhirConversionHistoryRepository.save(h);
-
-                //Change to new fhir set id.
-                v.forEach(measure -> {
-                    MeasureSet newMeasureSet = new MeasureSet();
-                    newMeasureSet.setId(newSetId);
-                    measureSetRepository.save(newMeasureSet);
-                    measure.setMeasureSetId(newMeasureSet);
-                    measureRepository.save(measure);
-                    CqlLibrary cqlLibrary = cqlLibraryRepository.getCqlLibraryByMeasureId(measure.getId());
-                    if (cqlLibrary != null) {
-                        cqlLibrary.setSetId(newSetId);
-                        cqlLibraryRepository.save(cqlLibrary);
-                    }
-                    addToListMap(result.getSuccessSetIdToFhirMeasures(), newSetId, measure.getId());
-                });
-            } else {
-                log.info("fhirConversionHistory exists for " + k + " skipping.");
-            }
-        });
-
-        return result;
-    }
-
-    private void addToListMap(Map<String, List<String>> map, String key, String value) {
-        var valueList = map.get(key);
-        if (valueList == null) {
-            valueList = new ArrayList<>();
-            map.put(key, valueList);
-        }
-        valueList.add(value);
     }
 }

--- a/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/rest/StandAloneLibraryController.java
+++ b/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/rest/StandAloneLibraryController.java
@@ -1,8 +1,5 @@
 package gov.cms.mat.fhir.services.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.cms.mat.fhir.commons.model.CqlLibrary;
-import gov.cms.mat.fhir.commons.model.FhirConversionHistory;
 import gov.cms.mat.fhir.rest.dto.ConversionResultDto;
 import gov.cms.mat.fhir.rest.dto.ConversionType;
 import gov.cms.mat.fhir.services.components.reporting.ConversionReporter;
@@ -10,7 +7,6 @@ import gov.cms.mat.fhir.services.components.reporting.ConversionResultsService;
 import gov.cms.mat.fhir.services.components.reporting.ThreadSessionKey;
 import gov.cms.mat.fhir.services.components.xml.XmlSource;
 import gov.cms.mat.fhir.services.repository.CqlLibraryRepository;
-import gov.cms.mat.fhir.services.repository.FhirConversionHistoryRepository;
 import gov.cms.mat.fhir.services.service.orchestration.PushLibraryService;
 import gov.cms.mat.fhir.services.summary.OrchestrationProperties;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,9 +23,11 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.constraints.Min;
-import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping(path = "/library")
@@ -53,16 +51,13 @@ public class StandAloneLibraryController {
     private final ConversionResultsService conversionResultsService;
     private final PushLibraryService pushLibraryService;
     private final CqlLibraryRepository cqlLibraryRepository;
-    private final FhirConversionHistoryRepository fhirConversionHistoryRepository;
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public StandAloneLibraryController(ConversionResultsService conversionResultsService,
                                        PushLibraryService pushLibraryService,
-                                       CqlLibraryRepository cqlLibraryRepository, FhirConversionHistoryRepository fhirConversionHistoryRepository) {
+                                       CqlLibraryRepository cqlLibraryRepository) {
         this.conversionResultsService = conversionResultsService;
         this.pushLibraryService = pushLibraryService;
         this.cqlLibraryRepository = cqlLibraryRepository;
-        this.fhirConversionHistoryRepository = fhirConversionHistoryRepository;
     }
 
     @Operation(summary = "Orchestrate QDM to Hapi FHIR Library with the id",
@@ -97,60 +92,6 @@ public class StandAloneLibraryController {
         OrchestrationProperties orchestrationProperties =
                 buildProperties(ConversionType.CONVERSION, true, Boolean.FALSE, threadSessionKey);
         return pushLibraryService.convertStandAloneFromMatToFhir(id, orchestrationProperties);
-    }
-
-    /**
-     * Remove me after FHIR 6.04 release.
-     * @return
-     */
-    @Operation(summary = "For 6.04 release, converts libs to new set id. Not usable after 6.04 release")
-    @GetMapping("/dbConversionForFhirConversionIn6dot04")
-    public @ResponseBody ConvertFhirLibsResult dbConversionForFhirConversionIn6dot04() {
-        ConvertFhirLibsResult result = new ConvertFhirLibsResult();
-        var libIds = cqlLibraryRepository.getAllStandaloneCqlFhirLibs();
-
-        //Place in a map by qdm set id.
-        var mapBySetId = new HashMap<String, List<CqlLibrary>>();
-        libIds.forEach(l -> {
-            List<CqlLibrary> libs = mapBySetId.get(l.getSetId());
-            if (libs == null) {
-                libs = new ArrayList<>();
-                mapBySetId.put(l.getSetId(), libs);
-            }
-            libs.add(l);
-        });
-
-        mapBySetId.forEach((k, v) -> {
-            if (fhirConversionHistoryRepository.findById(k).isEmpty()) {
-                String newSetId = UUID.randomUUID().toString();
-                //Create new FhirConversionHistory.
-                var h = new FhirConversionHistory();
-                h.setFhirSetId(newSetId);
-                h.setQdmSetId(k);
-                h.setLastModifiedOn(new Timestamp(System.currentTimeMillis()));
-                fhirConversionHistoryRepository.save(h);
-
-                //Change to new fhir set id.
-                v.forEach(l -> {
-                    l.setSetId(newSetId);
-                    cqlLibraryRepository.save(l);
-                    addToListMap(result.getSuccessSetIdToFhirLib(), newSetId, l.getId());
-                });
-            } else {
-                log.info("fhirConversionHistory exists for " + k + " skipping.");
-            }
-        });
-
-        return result;
-    }
-
-    private void addToListMap(Map<String, List<String>> map, String key, String value) {
-        var valueList = map.get(key);
-        if (valueList == null) {
-            valueList = new ArrayList<>();
-            map.put(key, valueList);
-        }
-        valueList.add(value);
     }
 
     @Operation(summary = "Pushes all versioned fhir libs in the mat DB into the hapi fhir db.",


### PR DESCRIPTION
Removing the one-off endpoints that spilt previously converted QDM -> FHIR measures into their own measure family (unique measure set IDs).

Cleaned up supporting code that was no longer used after the endpoint removal.﻿
