### PR TITLE
[MAT-2660] Ignore Draft Libraries on PushAllVersionedLibs

### DIFF
--- a/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/repository/CqlLibraryRepository.java
+++ b/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/repository/CqlLibraryRepository.java
@@ -25,8 +25,8 @@ public interface CqlLibraryRepository extends JpaRepository<CqlLibrary, String> 
     @Query("select a from CqlLibrary a where a.measureId = :measureId")
     CqlLibrary getCqlLibraryByMeasureId(String measureId);
 
-    @Query("select a from CqlLibrary a where a.cqlName = :cqlName and a.version = :version")
-    Optional<CqlLibrary> getCqlLibraryByNameAndVersion(String cqlName, BigDecimal version);
+    @Query("select a from CqlLibrary a where a.cqlName = :cqlName and a.version = :version and a.libraryModel = 'FHIR' and a.draft = false")
+    Optional<CqlLibrary> getVersionedCqlLibraryByNameAndVersion(String cqlName, BigDecimal version);
 
     List<CqlLibrary> findByQdmVersionAndCqlNameAndVersionAndLibraryModelAndFinalizedDateIsNotNull(String qdmVersion,
                                                                                                   String cqlName,

--- a/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/rest/StandAloneLibraryController.java
+++ b/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/rest/StandAloneLibraryController.java
@@ -172,7 +172,7 @@ public class StandAloneLibraryController implements CqlVersionConverter {
     private Optional<CqlLibrary> findStandardCqlLibrary(String cqlName, String versionString) {
         BigDecimal versionDecimal = convertVersionToBigDecimal(versionString);
         String fhirCqlName = convertCqlNameToFhir(cqlName);
-        return cqlLibraryRepository.getCqlLibraryByNameAndVersion(fhirCqlName, versionDecimal);
+        return cqlLibraryRepository.getVersionedCqlLibraryByNameAndVersion(fhirCqlName, versionDecimal);
     }
 
     private String convertCqlNameToFhir(String cqlName) {

--- a/mat-fhir-services/src/test/java/gov/cms/mat/fhir/services/rest/StandAloneLibraryControllerTest.java
+++ b/mat-fhir-services/src/test/java/gov/cms/mat/fhir/services/rest/StandAloneLibraryControllerTest.java
@@ -70,6 +70,7 @@ class StandAloneLibraryControllerTest {
         cqlLibrary.setLibraryModel("FHIR");
         cqlLibrary.setVersion(new BigDecimal("1.0"));
         cqlLibrary.setRevisionNumber(2);
+        cqlLibrary.setDraft(false);
 
         when(cqlLibraryRepository.getAllVersionedCqlFhirLibs()).thenReturn(Collections.singletonList(ID));
         when(cqlLibraryRepository.getCqlLibraryById(Mockito.eq(ID))).thenReturn(cqlLibrary);


### PR DESCRIPTION
MAT permits two Library entries to have the same
Version number as long as one is in Draft status.

The select query used to retrieve the Library contents
by version number and name also needs to filter by draft and
library model to ignore the draft Library.
