### PR TITLE
Set the cqframework dependencies to a timestamped SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,22 +107,22 @@
             <dependency>
                 <groupId>info.cqframework</groupId>
                 <artifactId>cql</artifactId>
-                <version>${cqframework.version}</version>
+                <version>1.5.2-20210210.000412-5</version>
             </dependency>
             <dependency>
                 <groupId>info.cqframework</groupId>
                 <artifactId>model</artifactId>
-                <version>${cqframework.version}</version>
+                <version>1.5.2-20210210.000512-5</version>
             </dependency>
             <dependency>
                 <groupId>info.cqframework</groupId>
                 <artifactId>cql-to-elm</artifactId>
-                <version>${cqframework.version}</version>
+                <version>1.5.2-20210210.000425-5</version>
             </dependency>
             <dependency>
                 <groupId>info.cqframework</groupId>
                 <artifactId>elm</artifactId>
-                <version>${cqframework.version}</version>
+                <version>1.5.2-20210210.000504-5</version>
             </dependency>
             <dependency>
                 <groupId>info.cqframework</groupId>


### PR DESCRIPTION
To prevent further breakage by accepting unexpected SNAPSHOT updates,
locking the various cqframework dependencies to their last known
"good" version. That being right before the 6.04 release on
Feb 11, 2021.
