### PR TITLE
Ignore local maven repo when building

### DIFF
--- a/cql-elm-wrapper/pom.xml
+++ b/cql-elm-wrapper/pom.xml
@@ -20,14 +20,14 @@
 	</properties>
 	
 	<repositories>
-		<repository>
-			<id>cqframework-local</id>
-			<name>Local cqframework SNAPSHOT</name>
-			<url>file://${project.basedir}/../libs</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
+<!--		<repository>-->
+<!--			<id>cqframework-local</id>-->
+<!--			<name>Local cqframework SNAPSHOT</name>-->
+<!--			<url>file://${project.basedir}/../libs</url>-->
+<!--			<snapshots>-->
+<!--				<enabled>true</enabled>-->
+<!--			</snapshots>-->
+<!--		</repository>-->
 		<repository>
 			<id>oss-sonatype</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots</url>

--- a/pom.xml
+++ b/pom.xml
@@ -157,14 +157,14 @@
     </modules>
 
     <repositories>
-        <repository>
-            <id>cqframework-local</id>
-            <name>Local cqframework SNAPSHOT</name>
-            <url>file://${project.basedir}/libs</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
+<!--        <repository>-->
+<!--            <id>cqframework-local</id>-->
+<!--            <name>Local cqframework SNAPSHOT</name>-->
+<!--            <url>file://${project.basedir}/libs</url>-->
+<!--            <snapshots>-->
+<!--                <enabled>true</enabled>-->
+<!--            </snapshots>-->
+<!--        </repository>-->
         <repository>
             <id>oss-sonatype</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>


### PR DESCRIPTION
A fix for the 'missing ELM' issue in cqframework SNAPSHOT has been pushed to the public repos making the local repo no longer needed.
