### PR TITLE
Version is set to '0.0.000' for QDM-FHIR conversion

### DIFF
--- a/cql-elm-translation/src/test/java/gov/cms/mat/cql_elm_translation/service/MatXmlConversionServiceTest.java
+++ b/cql-elm-translation/src/test/java/gov/cms/mat/cql_elm_translation/service/MatXmlConversionServiceTest.java
@@ -26,6 +26,6 @@ class MatXmlConversionServiceTest implements ResourceFileUtil {
     void processCalXml_SendValidXml() {
         String xml = getData("/test_mat_cql.xml");
         String cql = matXmlConversionService.processCqlXml(xml);
-        assertTrue(cql.startsWith("library THKR version '1.13.000'"));
+        assertTrue(cql.startsWith("library THKR version '0.0.000'"));
     }
 }

--- a/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/rest/OrchestrationController.java
+++ b/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/rest/OrchestrationController.java
@@ -111,7 +111,7 @@ public class OrchestrationController implements OrchestrationParameterChecker {
         }
     }
 
-    public ConversionResultDto process(OrchestrationProperties orchestrationProperties) {
+    private ConversionResultDto process(OrchestrationProperties orchestrationProperties) {
         log.debug("Started Orchestrating Measure key: {}", orchestrationProperties.getThreadSessionKey());
         orchestrationService.process(orchestrationProperties);
         return conversionResultProcessorService.process(orchestrationProperties.getThreadSessionKey());

--- a/mat-fhir-services/src/test/java/gov/cms/mat/fhir/services/rest/MatXmlControllerTest.java
+++ b/mat-fhir-services/src/test/java/gov/cms/mat/fhir/services/rest/MatXmlControllerTest.java
@@ -120,8 +120,7 @@ class MatXmlControllerTest implements ResourceFileUtil {
 //                any(), any(ValidationRequest.class))).thenReturn(Collections.emptyList());
 
         CqlLibrary cqlLibrary = new CqlLibrary();
-        String cqlXml = getStringFromResource("/cqlLookUp.xml");
-        cqlLibrary.setCqlXml(cqlXml);
+        cqlLibrary.setCqlXml(getStringFromResource("/cqlLookUp.xml"));
         when(cqlLibraryRepository.findById(ID)).thenReturn(Optional.of(cqlLibrary));
         MatXmlController.MatXmlReq matXmlReq = new MatXmlController.MatXmlReq();
 
@@ -136,8 +135,8 @@ class MatXmlControllerTest implements ResourceFileUtil {
                 matXmlController.fromStandaloneLib(ULMS_TOKEN, API_KEY, ID, matXmlReq, mockHttpServletResponse);
 
         assertEquals("AIS_HEDIS_2020", response.getCqlModel().getLibraryName());
-        assertEquals("1.0.000", response.getCqlModel().getVersionUsed());
-        assertTrue(response.getCql().startsWith("library AIS_HEDIS_2020 version '1.0.000'"));
+        assertEquals("0.0.000", response.getCqlModel().getVersionUsed());
+        assertTrue(response.getCql().startsWith("library AIS_HEDIS_2020 version '0.0.000'"));
     }
 
     @Test
@@ -206,7 +205,7 @@ class MatXmlControllerTest implements ResourceFileUtil {
 
         MatXmlController.MatXmlResponse response =    matXmlController.fromMeasure(ULMS_TOKEN, API_KEY, ID, matXmlReq, mockHttpServletResponse);
 
-        assertTrue(response.getCql().startsWith("library CDAYTest version '1.0.000'"));
+        assertTrue(response.getCql().startsWith("library CDAYTest version '0.0.000'"));
     }
 
     @Test

--- a/mat-server-commons/src/main/java/mat/server/CQLUtilityClass.java
+++ b/mat-server-commons/src/main/java/mat/server/CQLUtilityClass.java
@@ -97,7 +97,7 @@ public final class CQLUtilityClass {
         AtomicInteger size = new AtomicInteger(0);
         StringBuilder cqlStr = new StringBuilder();
         // library Name and Using
-        cqlStr.append(CQLUtilityClass.createLibraryNameSection(cqlModel));
+        cqlStr.append(CQLUtilityClass.createLibraryNameSection(cqlModel, isFhir));
 
         //includes
         cqlStr.append(CQLUtilityClass.createIncludesSection(cqlModel.getCqlIncludeLibrarys()));
@@ -132,13 +132,13 @@ public final class CQLUtilityClass {
         return Pair.of(cqlStr.toString(), size.get());
     }
 
-    private static String createLibraryNameSection(CQLModel cqlModel) {
+    private static String createLibraryNameSection(CQLModel cqlModel, boolean isFhir) {
         StringBuilder sb = new StringBuilder();
 
         if (StringUtils.isNotBlank(cqlModel.getLibraryName())) {
 
             sb.append("library ").append(cqlModel.getLibraryName());
-            sb.append(VERSION).append("'" + cqlModel.getVersionUsed()).append("'");
+            sb.append(VERSION).append("'" + (isFhir ? cqlModel.getVersionUsed() : "0.0.000")).append("'");
             sb.append(System.lineSeparator()).append(System.lineSeparator());
 
             if (StringUtils.isNotBlank(cqlModel.getLibraryComment())) {


### PR DESCRIPTION
[MAT-2921](https://jira.cms.gov/browse/MAT-2921)

Upon converting a QDM measure to FHIR, the Measure cql string is not set to '0.0.000'. while the measure is restarted as a brand new measure. 

isFhir is used to identify the Conversion process. Since the only time, a QDM measure hits this service is during the Conversion process.  