### PR TITLE
[MAT-3095] Permit no-arg CQL Functions

### DIFF
--- a/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/cql/parser/CqlToMatXml.java
+++ b/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/cql/parser/CqlToMatXml.java
@@ -359,10 +359,6 @@ public class CqlToMatXml implements CqlVisitor {
             handleError(severErrorAtLine("define function must have a name", lineNumber));
             hasSeveres = true;
         }
-        if (CollectionUtils.isEmpty(args)) {
-            handleError(severErrorAtLine("define function must have arguments", lineNumber));
-            hasSeveres = true;
-        }
         if (StringUtils.isBlank(logic)) {
             handleError(severErrorAtLine("define function must have logic", lineNumber));
             hasSeveres = true;

--- a/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/service/ValidationOrchestrationService.java
+++ b/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/service/ValidationOrchestrationService.java
@@ -192,6 +192,9 @@ public class ValidationOrchestrationService {
     }
 
     private List<CQLExpressionOprandObject> convert(CQLFunctions function) {
+        if (CollectionUtils.isEmpty(function.getArgumentList())) {
+            return Collections.emptyList();
+        }
         return function.getArgumentList().stream().map(a -> {
             var operand = new CQLExpressionOprandObject();
             operand.setName(a.getArgumentName());

--- a/mat-fhir-services/src/test/java/gov/cms/mat/fhir/services/cql/parser/AntlrCqlToMatXmlTest.java
+++ b/mat-fhir-services/src/test/java/gov/cms/mat/fhir/services/cql/parser/AntlrCqlToMatXmlTest.java
@@ -327,7 +327,7 @@ public class AntlrCqlToMatXmlTest {
     public void testFunctionFhirComment() throws Exception {
         var destination = parseModel("testfunctions_fhir.cql");
 
-        assertEquals(2, destination.getCqlFunctions().size());
+        assertEquals(3, destination.getCqlFunctions().size());
         assertEquals("testfunction", destination.getCqlFunctions().get(0).getName());
         assertEquals("testfunction comment", destination.getCqlFunctions().get(0).getCommentString());
         assertEquals("testpopulationfunction", destination.getCqlFunctions().get(1).getName());

--- a/mat-fhir-services/src/test/java/gov/cms/mat/fhir/services/cql/parser/CqlToMatXmlTest.java
+++ b/mat-fhir-services/src/test/java/gov/cms/mat/fhir/services/cql/parser/CqlToMatXmlTest.java
@@ -303,11 +303,18 @@ public class CqlToMatXmlTest {
     public void testFunctionFhirComment() throws Exception {
         var destination = parseModel("testfunctions_fhir.cql");
 
-        assertEquals(2, destination.getCqlFunctions().size());
+        assertEquals(3, destination.getCqlFunctions().size());
         assertEquals("testfunction", destination.getCqlFunctions().get(0).getName());
         assertEquals("testfunction comment", destination.getCqlFunctions().get(0).getCommentString());
         assertEquals("testpopulationfunction", destination.getCqlFunctions().get(1).getName());
         assertEquals("testpopulationfunction comment", destination.getCqlFunctions().get(1).getCommentString());
+    }
+
+    @Test
+    public void testNoArgFunctionPasses() throws Exception {
+        var model = parseModel("testfunctions_fhir.cql");
+        // 3rd function in test file has 0 args
+        assertEquals(0, model.getCqlFunctions().get(2).getArgumentList().size());
     }
 
     @Test

--- a/mat-fhir-services/src/test/resources/test-cql/testfunctions_fhir.cql
+++ b/mat-fhir-services/src/test/resources/test-cql/testfunctions_fhir.cql
@@ -11,3 +11,6 @@ define function "testfunction"(arg1 Boolean, arg2 Interval<DateTime>, arg3 "Enco
 /*testpopulationfunction comment*/
 define function "testpopulationfunction"(arg1 Boolean):
   true
+
+define function "testNoArgsFunction"():
+  false


### PR DESCRIPTION
The CQL specification permits Functions to have 0 arguments; however, the current validation does not.

According to older commits, the arg validation rule was added to prevent 500 errors. As best I can tell, the 500s were caused by the Function's argument list being null at time of converting the `CQLFunction` object to an `CQLExpressionOprandObject`. 

Adding a null/empty check to the args list when populating the `CQLExpressionOprandObject`.