### PR TITLE
Check for `urn:oid:` prefix before prepending said prefix

### DIFF
--- a/mat-server-commons/src/main/java/mat/server/CQLUtilityClass.java
+++ b/mat-server-commons/src/main/java/mat/server/CQLUtilityClass.java
@@ -489,7 +489,12 @@ public final class CQLUtilityClass {
 
                         if (!codeSystemAlreadyUsed.contains(codeSysStr)) {
                             sb.append("codesystem \"").append(codeSysStr).append('"').append(": ");
-                            sb.append("'urn:oid:").append(code.getCodeSystemOID()).append("' ");
+                            if(code.getCodeSystemOID().startsWith("urn:oid:")) {
+                                sb.append('\'');
+                            } else {
+                                sb.append("'urn:oid:");
+                            }
+                            sb.append(code.getCodeSystemOID()).append("' ");
                             sb.append(codeSysVersion);
                             sb.append("\n");
 


### PR DESCRIPTION
The CDCREC Code System's FHIR URL is an OID with the `urn:oid` prefix, the first OID based FHIR URL accepted by the MAT. As a result, it is triggering older QDM code that expects the code system OID to come from VSAC without the prefix and adds it to the CQL `codesystem` statement.

The FHIR URL comes from the code system mapping json, instead of VSAC, and the mapping entry is also used for validation, requiring the code system url in the CQL match the mapping entry exactly. Hence, the prefix must be present in the mapping entry.
