### PR TITLE
Exclude FHIRHelpers during unused library check

### DIFF
--- a/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/components/validation/unused/LibraryUnusedValidator.java
+++ b/mat-fhir-services/src/main/java/gov/cms/mat/fhir/services/components/validation/unused/LibraryUnusedValidator.java
@@ -20,6 +20,8 @@ public class LibraryUnusedValidator extends UnusedValidatorBase<CQLIncludeLibrar
         } else {
             return cqlModel.getCqlIncludeLibrarys()
                     .stream()
+                    //Ignore FHIRHelpers when determining unused list. It is needed for under-the-hood processing by the Translator.
+                    .filter(l -> !l.getCqlLibraryName().equals("FHIRHelpers"))
                     .filter(this::isNotUsedInCql)
                     .collect(Collectors.toList());
         }

--- a/mat-fhir-services/src/test/java/gov/cms/mat/fhir/services/components/validation/unused/LibraryUnusedValidatorTest.java
+++ b/mat-fhir-services/src/test/java/gov/cms/mat/fhir/services/components/validation/unused/LibraryUnusedValidatorTest.java
@@ -61,6 +61,7 @@ class LibraryUnusedValidatorTest {
     private CQLIncludeLibrary createIncludeLibrary(String alias) {
         CQLIncludeLibrary cqlIncludeLibrary = new CQLIncludeLibrary();
         cqlIncludeLibrary.setAliasName(alias);
+        cqlIncludeLibrary.setCqlLibraryName(alias);
         return cqlIncludeLibrary;
     }
 }


### PR DESCRIPTION
When building the list of unused libraries, ignore FHIRHelpers.

FHIRHelpers is used by the Translator to handle conversion between the FHIR and CQL System models. A common example is when comparing an element on a FHIR Resource that has a required binding (i.e. Encounter.status ~ 'finished'), the left side of the comparison is a FHIR type, FHIR.EncounterStatus, while the right side is System.String. FHIRHelpers is by the Translator to convert the left side to System.String for a consistent comparison.

Thus, FHIRHelpers can be used without being explicitly referenced in a library's definitions or functions, which would normally make it "unused" and eligible for optional removal at versioning.
