### PR TITLE
Null check to make sure that MADIE doesn't receive 500

### DIFF
--- a/cql-elm-translation/src/main/java/gov/cms/mat/cql_elm_translation/cql_translator/TranslationResource.java
+++ b/cql-elm-translation/src/main/java/gov/cms/mat/cql_elm_translation/cql_translator/TranslationResource.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 public class TranslationResource {
 
-    private static final MultivaluedMap<String, CqlTranslator.Options> PARAMS_TO_OPTIONS_MAP = new MultivaluedHashMap<String, CqlTranslator.Options>() {{
+    private static final MultivaluedMap<String, CqlTranslator.Options> PARAMS_TO_OPTIONS_MAP = new MultivaluedHashMap<>() {{
         putSingle("date-range-optimization", CqlTranslator.Options.EnableDateRangeOptimization);
         putSingle("annotations", CqlTranslator.Options.EnableAnnotations);
         putSingle("locators", CqlTranslator.Options.EnableLocators);
@@ -60,6 +60,11 @@ public class TranslationResource {
 
         this.libraryManager = new LibraryManager(modelManager);
     }
+
+    /**
+     * sets the options and calls cql-elm-translator using MatLibrarySourceProvider,
+     * which helps the translator to fetch the CQL of the included libraries from HAPI.
+     */
 
     public CqlTranslator buildTranslator(InputStream cqlStream, MultivaluedMap<String, String> params) {
         try {

--- a/cql-elm-translation/src/main/java/gov/cms/mat/cql_elm_translation/service/CqlConversionService.java
+++ b/cql-elm-translation/src/main/java/gov/cms/mat/cql_elm_translation/service/CqlConversionService.java
@@ -70,7 +70,7 @@ public class CqlConversionService {
         CqlTextParser cqlTextParser = new CqlTextParser(new String(requestData.getCqlDataInputStream().readAllBytes()));
         UsingProperties usingProperties = cqlTextParser.getUsing();
 
-        return new TranslationResource(usingProperties.isFhir())
+        return new TranslationResource(usingProperties != null && usingProperties.isFhir())
                 .buildTranslator(requestData.getCqlDataInputStream(), requestData.createMap());
     }
 

--- a/cql-elm-translation/src/main/java/gov/cms/mat/cql_elm_translation/service/support/CqlExceptionErrorProcessor.java
+++ b/cql-elm-translation/src/main/java/gov/cms/mat/cql_elm_translation/service/support/CqlExceptionErrorProcessor.java
@@ -21,6 +21,9 @@ public class CqlExceptionErrorProcessor {
     private final String json;
     private final Library library;
 
+    /**
+     * Transforms CqlTranslatorException to MatCqlConversionException and prepend with "errorExceptions" object to the translator.json
+     */
     public CqlExceptionErrorProcessor(List<CqlTranslatorException> cqlErrors, String json, Library library) {
         this.cqlErrors = cqlErrors;
         this.json = json;
@@ -47,9 +50,7 @@ public class CqlExceptionErrorProcessor {
         List<MatCqlConversionException> matErrors = buildMatErrors();
         String jsonToInsert = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(matErrors);
 
-        String temp = json.replaceFirst("\n", "\n  \"errorExceptions\":" + jsonToInsert + ",\n");
-
-        return temp;
+        return json.replaceFirst("\n", "\n  \"errorExceptions\":" + jsonToInsert + ",\n");
     }
 
     private String escape(String raw) {
@@ -116,7 +117,6 @@ public class CqlExceptionErrorProcessor {
         MatCqlConversionException matCqlConversionException = new MatCqlConversionException();
         matCqlConversionException.setErrorSeverity(c.getSeverity().name());
 
-
         try {
             String payload = escape(c.getMessage());
             matCqlConversionException.setMessage(payload);
@@ -124,8 +124,6 @@ public class CqlExceptionErrorProcessor {
             log.debug("Error building MatError", e);
             matCqlConversionException.setMessage("Exception");
         }
-
         return matCqlConversionException;
     }
-
 }


### PR DESCRIPTION
"usingProperties" is null when the cql string doesn't have the following statement.

`using FHIR version '4.0.1'`

Null check to make sure that the service returns a 200 with the errors that are sent by the translator.

Story
[MAT-3958](https://jira.cms.gov/browse/MAT-3958)