### PR TITLE
Resolve CVE-2022-22965

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.2</version>
+        <version>2.4.13</version>
         <relativePath/>
     </parent>
     <groupId>gov.cms.mat</groupId>


### PR DESCRIPTION
Bump Spring Boot Parent Starter to resolve CVE-2022-22965.