### PR TITLE
Allow circular references during bean creation in hapi

### DIFF
--- a/hapi-fhir-jpaserver/src/main/resources/application.yaml
+++ b/hapi-fhir-jpaserver/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 server:
   port: 6060
 spring:
+  main:
+    allow-circular-references: true
   datasource:
     driverClassName: com.mysql.cj.jdbc.Driver
     url: ${HAPI_DB_URL}


### PR DESCRIPTION
Newer versions of hapi jpa server are failing to start due to circular references during bean creation. Since the beans in question are internal to HAPI, we are electing to permit circular references in the spring config.